### PR TITLE
Make attribute count error consistent with Moo

### DIFF
--- a/lib/MooX/Enumeration.pm
+++ b/lib/MooX/Enumeration.pm
@@ -39,12 +39,14 @@ sub setup_for {
 	ref($orig) or croak("$target doesn't have a `has` function");
 	
 	$target->$installer(has => sub {
-		if (@_ % 2 == 0) {
-			croak "Invalid options for attribute(s): even number of arguments expected, got " . scalar @_;
-		}
-		
-		my ($attrs, %spec) = @_;
+		my $attrs = shift;
 		$attrs = [$attrs] unless ref $attrs;
+		if (@_ % 2 != 0) {
+			croak "Invalid options for " . join(', ', map "'$_'", @$attrs)
+				. " attribute(s): even number of arguments expected, got " . scalar @_;
+		}
+
+		my %spec = @_;
 		for my $attr (@$attrs) {
 			%spec = $class->process_spec($target, $attr, %spec);
 			if (delete $spec{moox_enumeration_process_handles}) {


### PR DESCRIPTION
The current error message for bad argument counts in "has" is a bit confusing.

With Moo:
```
$ perl -e 'package Foo; use Moo; has stuff => (is => "rw", "isa")'
Invalid options for 'stuff' attribute(s): even number of arguments expected, got 3 at -e line 1.
```
With MooX::Enumeration:
```
$ perl -e 'package Foo; use Moo; use MooX::Enumeration; has stuff => (is => "rw", "isa")'
Invalid options for attribute(s): even number of arguments expected, got 4 at -e line 1.
```

This patch makes the MooX::Enumeration message identical to Moo.